### PR TITLE
Cargo aging tweaks

### DIFF
--- a/JPplus.nml
+++ b/JPplus.nml
@@ -1,8 +1,6 @@
-# 1 "JPplus.pnml"
 /*---HEADER--*/
 
 //Define the GRF
-# 1 "src/header.pnml" 1
 grf {
 	grfid:	"BS\13\20";
 	name:	string(STR_GRF_NAME);
@@ -131,10 +129,8 @@ grf {
 			 }
 		}
 }
-# 1 "JPplus.pnml" 4
 
 //Helpers
-# 1 "src/basecosts.pnml" 1
 basecost {
 		 PR_BUILD_VEHICLE_TRAIN : param_basecostbuy -1;
 		 PR_BUILD_VEHICLE_WAGON: param_basecostbuy +3;
@@ -142,8 +138,6 @@ basecost {
 		 PR_RUNNING_TRAIN_DIESEL: param_basecostrun +1;
 		 PR_RUNNING_TRAIN_ELECTRIC: param_basecostrun +1;
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/railtypetable.pnml" 1
 /*railtypetable {
     "3RDR", "3RDC", RLOW, ELOW, RHIG, EHIG, HSTR, NGRL, ELNG, NLOW, ENLW, ENHI, RAIL, ELRL,
 }*/
@@ -158,13 +152,9 @@ railtypetable {
 	STANDARD_3RDR: [SAB3, SAA3, RAIL],
 	STANDARD_OHLE: [SAAE, ELRL],
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/cargotable.pnml" 1
 cargotable {
 	PASS,
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/parameters.pnml" 1
 /*	CAPCITY BOOST	*/
 if (param_boostcapacity == 1)
 {
@@ -258,8 +248,6 @@ if (param_cargodecay >= 2) {
 	param_decay_rapid = 650;
 	param_decay_express = 1000;
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/template.pnml" 1
 //[(left_x, upper_y, width, height, )offset_x, offset_y(, flags)(, filename)(, mask)]
 
 /*Purchase Templates*/
@@ -557,10 +545,8 @@ template tmpl_7l_rev(x,y){
 //[x +97,  y,	22,	20,		-13,	-13] //dia1
 //[x +120, y,	32,	17,		-14,	-13] //long
 //[x+153,  y,	22,	20,		-5, 	-12] //dia2
-# 1 "JPplus.pnml" 4
 
 //IDs
-# 1 "src/vehicleid.pnml" 1
 
 item(FEAT_TRAINS, mu_car, 1000) {} //mucar 				0x3E8
 item(FEAT_TRAINS, mu_cardd, 1001) {} //mucardd 		0x3E9
@@ -666,14 +652,12 @@ item(FEAT_TRAINS, emu_315, 2071) {} //107emu 0x7E2
 item(FEAT_TRAINS, emu_713, 2072) {} //107emu 0x7E2
 item(FEAT_TRAINS, emu_583, 2073) {} //107emu 0x7E2
 item(FEAT_TRAINS, emu_417, 2074) {} //107emu 0x7E2
-# 1 "JPplus.pnml" 4
 
 //Coupliung Rules
 //#include "src/attach_kiha_group.pnml"
 //#include "src/attach_211_213_group.pnml"
 
 //Sorting
-# 1 "src/sorting.pnml" 1
 sort(FEAT_TRAINS, [
 
 /* **EMU** */
@@ -843,10 +827,8 @@ mu_cab,
 mu_cardd,
 
 ]);
-# 1 "JPplus.pnml" 4
 
 //Final Settings
-# 1 "src/grfintegration.pnml" 1
 //set depot vehicle width to 32px to avoid overlap
 train_width_32_px = 1;
 //align train properly in depot window
@@ -883,10 +865,8 @@ if (grf_order_behind("SZ\0D\00") == 0) {
 if (grf_order_behind("JD\A1\E1") == 0) {
 	error(WARNING, string(GRF_JAPANSECRETORDER));
 }
-# 1 "JPplus.pnml" 4
 
 //Reversing
-# 1 "src/reversing/reversing_211_213_311_313_group.pnml" 1
 /*---GFX: Spritesets---*/
 
 /*---211---*/
@@ -1883,8 +1863,6 @@ switch(FEAT_TRAINS, SELF, sw_211group_gfx_rev_idcheck, [STORE_TEMP(position_in_c
   2024: sw_211group_gfx_rev_313_frontback;
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/reversing/reversing_KH_110_111_E120_E130_E131_group.pnml" 1
 
 
 /*---GFX: Spritesets---*/
@@ -2340,8 +2318,6 @@ switch(FEAT_TRAINS, SELF, sw_JREKHgroup_gfx_rev_idcheck, [STORE_TEMP(position_in
 /*---END OF SECTION---*/
 
 
-# 1 "JPplus.pnml" 4
-# 1 "src/reversing/reversing_E231_E233_group.pnml" 1
 /*---GFX: Spritesets---*/
 
 /*---E231---*/
@@ -3257,8 +3233,6 @@ switch(FEAT_TRAINS, SELF, sw_E231group_gfx_rev_idcheck, [STORE_TEMP(position_in_
   2016: sw_E233_gfx_rev_frontback; 
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/reversing/reversing_415_group.pnml" 1
 /*415-1500*/
 //Purchase Sprites
 spriteset (spriteset_4151500_purchase,	                                                    "gfx/JNR/emu415_1500/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -5384,8 +5358,6 @@ switch(FEAT_TRAINS, SELF, sw_415group_gfx_rev_idcheck, [STORE_TEMP(position_in_c
 switch(FEAT_TRAINS, SELF, sw_415group_attach_vehid, [vehicle_type_id == emu_413 ||vehicle_type_id == emu_4151500 || vehicle_type_id == emu_415 ||vehicle_type_id == emu_403 || vehicle_type_id == emu_401 || vehicle_type_id == mu_car]) {
  0: return string(MU_UNIQUE);
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/reversing/reversing_221_223_225_group.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_221_purchase,	                                                     "gfx/JRW/emu207/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -6666,8 +6638,6 @@ switch(FEAT_TRAINS, SELF, sw_JRW22group_gfx_rev_idcheck, [STORE_TEMP(position_in
   2054: sw_225_5000_gfx_rev_frontback;
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/reversing/reversing_JNR_KIHA_group.pnml" 1
 
 //Livery Selection kh30
 switch(FEAT_TRAINS,SELF, sw_KH30_gfx_rev_livery, [STORE_TEMP(position_in_consist_from_end-position_in_consist, 0x10F), var[0x61, 0, 0x0000FFFF, 0xF2]]){
@@ -7073,8 +7043,6 @@ switch(FEAT_TRAINS, SELF, sw_JNR_KH_subtypetext_mucar, cargo_subtype) {
     vehicle_type_id == mu_car]) {
   0: return string(STR_ATTACH_JNRKH);
   }
-# 1 "JPplus.pnml" 4
-# 1 "src/reversing/reversing_271_281_group.pnml" 1
 /*---271 SPRITESHEETS BLOCK---*/
 
 /*-Purchase Sprites-*/
@@ -7468,12 +7436,10 @@ switch(FEAT_TRAINS, SELF, sw_JRW271281group_gfx_rev_idcheck, [STORE_TEMP(positio
   2066: sw_281_gfx_rev_idcheck;
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
 
 /*---TRAINS---*/
 
 //Wagons
-# 1 "src/OTHER/mucar.pnml" 1
 /*---GFX: Spritesets---*/
 spriteset (set_mu_car_purchase,	    "gfx/OTHER/mucarbuy.png") 	{tmpl_purchase(0, 0)}
 spriteset (set_mu_car_base,       	"gfx/OTHER/mucar.png")     	{tmpl_std(0, 0)}
@@ -7493,6 +7459,7 @@ item(FEAT_TRAINS, mu_car) {
                 speed: 0 km/h;
                 power: 0 hp;
                 cargo_capacity: 1;
+                cargo_age_period: 185;
                 weight: 0 ton;
                 tractive_effort_coefficient: 0.3;
                 air_drag_coefficient: 0;
@@ -7521,10 +7488,8 @@ item(FEAT_TRAINS, mu_car) {
     }
 
 }
-# 1 "JPplus.pnml" 4
 
 //JGR
-# 1 "src/JGR/EMU/40_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_EMU40_purchase,	                                                            "gfx/JGR/emu40/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -7950,6 +7915,7 @@ item(FEAT_TRAINS, emu_40) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          54;
 
@@ -7991,6 +7957,7 @@ item(FEAT_TRAINS, emu_40) {
         default:                      sw_EMU40_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_EMU40_subtypetext_mucar;
         power: 132;
         weight: 40;
@@ -8008,6 +7975,7 @@ item(FEAT_TRAINS, emu_40sinlge) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          54;
 
@@ -8045,8 +8013,6 @@ item(FEAT_TRAINS, emu_40sinlge) {
         //start_stop:           ;
     }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JGR/EMU/52_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---SPRITESHEETS BLOCK---*/
@@ -9035,14 +9001,13 @@ item(FEAT_TRAINS, emu_52) {
         default:                      sw_52_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cargo_subtype_text:           sw_52_subtypetext_mucar;
         power: 200;
         weight: 34;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/JGR/EMU/63_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_EMU63_purchase,	                                                            "gfx/JGR/emu63/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -9261,6 +9226,7 @@ item(FEAT_TRAINS, emu_63) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  16;
         running_cost_factor:          53;
 
@@ -9302,13 +9268,12 @@ item(FEAT_TRAINS, emu_63) {
         default:                      sw_EMU63_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_EMU63_subtypetext_mucar;
         power: 132;
         weight: 61;
       }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JGR/EMU/6340_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 //Purchase Sprites
@@ -9476,6 +9441,7 @@ item(FEAT_TRAINS, emu_6340) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          55;
 
@@ -9517,6 +9483,7 @@ item(FEAT_TRAINS, emu_6340) {
         default:                      sw_6340_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_6340_subtypetext_mucar;
         power: 120;
         weight: 23;
@@ -9524,8 +9491,6 @@ item(FEAT_TRAINS, emu_6340) {
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JGR/EMU/6310_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 //Purchase Sprites
@@ -9634,6 +9599,7 @@ item(FEAT_TRAINS, emu_6310) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          55;
 
@@ -9671,11 +9637,9 @@ item(FEAT_TRAINS, emu_6310) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
 
 
 //JNR
-# 1 "src/JNR/DMU/KH30_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH30_purchase,	                                                    "gfx/JNR/dmuKH30/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -9788,6 +9752,7 @@ item(FEAT_TRAINS, dmu_kiha30) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -9829,13 +9794,12 @@ item(FEAT_TRAINS, dmu_kiha30) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 32;
       }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/DMU/KH35_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH35_purchase,	                                                    "gfx/JNR/dmuKH35/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -9983,6 +9947,7 @@ item(FEAT_TRAINS, dmu_kiha35) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -10024,13 +9989,12 @@ item(FEAT_TRAINS, dmu_kiha35) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 32;
       }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/DMU/KH40_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH40_purchase,	                                                    "gfx/JNR/dmuKH40/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -10338,6 +10302,7 @@ item(FEAT_TRAINS, dmu_kiha40) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -10378,13 +10343,12 @@ item(FEAT_TRAINS, dmu_kiha40) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 40;
       }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/DMU/KH54_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH54_purchase,	                                                    "gfx/JNR/dmuKH54/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -10520,6 +10484,7 @@ item(FEAT_TRAINS, dmu_kiha54) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -10560,13 +10525,12 @@ item(FEAT_TRAINS, dmu_kiha54) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 54;
       }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/DMU/KH58_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH58_purchase,	                                                    "gfx/JNR/dmuKH58/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -10760,6 +10724,7 @@ item(FEAT_TRAINS, dmu_kiha58) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cost_factor:                  15;
         running_cost_factor:          45;
 
@@ -10801,13 +10766,12 @@ item(FEAT_TRAINS, dmu_kiha58) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 40;
       }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/DMU/KH80_series.pnml" 1
 /*---!!!THIS HAS BEEN GENERATED BY JpyNML!!!---*/
 /*---END OF SECTION---*/
 /*---GFX: Spritesets---*/
@@ -11305,6 +11269,7 @@ item(FEAT_TRAINS, dmu_kiha80) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  18;
         running_cost_factor:          47;
 
@@ -11346,14 +11311,13 @@ item(FEAT_TRAINS, dmu_kiha80) {
         default:                      sw_KH80_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_KH80_subtypetext_mucar;
         power: 194;
         weight: 40;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/DMU/KH181_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH181_purchase,	                                                    "gfx/JNR/dmuKH181/purchase.png")               {tmpl_purchase(0, 0)}
@@ -11575,13 +11539,12 @@ item(FEAT_TRAINS, dmu_kiha181) {
         default:                      sw_KH181_gfx_mid;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_KH181_subtypetext_main;
         power: 181;
         weight: 42;
       }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/DMU/KH183_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH183_purchase,	                                                    "gfx/JNR/dmuKH183/purchase.png")               {tmpl_purchase(0, 0)}
@@ -11880,13 +11843,12 @@ item(FEAT_TRAINS, dmu_kiha183) {
         default:                      sw_KH183_gfx_mid;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_KH183_subtypetext_main;
         power: 183;
         weight: 42;
       }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/70_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---SPRITESHEETS BLOCK---*/
@@ -13007,6 +12969,7 @@ item(FEAT_TRAINS, emu_70) {
         reliability_decay:            23;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
         speed:                        100 km/h;
@@ -13044,14 +13007,13 @@ item(FEAT_TRAINS, emu_70) {
         default:                      sw_70_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_70_subtypetext_mucar;
         power: 284;
         weight: 32;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/80_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_80_purchase,	                                                     "gfx/JNR/emu80/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -13667,6 +13629,7 @@ item(FEAT_TRAINS, emu_80) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -13708,15 +13671,14 @@ item(FEAT_TRAINS, emu_80) {
         default:                      sw_80_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cargo_subtype_text:           sw_80_subtypetext_mucar;
         power: 568/2;
         weight: 32;
       }
 
 }
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JNR/EMU/103_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_103_purchase,	                                                    "gfx/JNR/emu101_103/purchase.png")               {tmpl_purchase_dh(0, 0)}
 alternative_sprites(spriteset_103_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JNR/emu101_103/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(0, 0)}
@@ -16099,6 +16061,7 @@ item(FEAT_TRAINS, emu_103) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  11;
         running_cost_factor:          41;
 
@@ -16140,14 +16103,13 @@ item(FEAT_TRAINS, emu_103) {
         default:                      sw_103_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_103_subtypetext_mucar;
         power: 440/2;
         weight: 26;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/111_113_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_113_purchase,	                                                    "gfx/JNR/emu111_113/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -17306,6 +17268,7 @@ item(FEAT_TRAINS, emu_113) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  14;
         running_cost_factor:          42;
 
@@ -17347,14 +17310,13 @@ item(FEAT_TRAINS, emu_113) {
         default:                      sw_113_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_113_subtypetext_mucar;
         power: 480/2;
         weight: 29;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/115_3000_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset(spriteset_1153000_purchase,	                                                    "gfx/JNR/emu115/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -17865,6 +17827,7 @@ item(FEAT_TRAINS, emu_1153000) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  16;
         running_cost_factor:          45;
 
@@ -17906,14 +17869,13 @@ item(FEAT_TRAINS, emu_1153000) {
         default:                      sw_1153000_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_1153000_subtypetext_mucar;
         power: 480/2;
         weight: 28;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/115_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset(spriteset_115_purchase,	                                                    "gfx/JNR/emu115/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -21688,6 +21650,7 @@ item(FEAT_TRAINS, emu_115) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  16;
         running_cost_factor:          45;
 
@@ -21729,14 +21692,13 @@ item(FEAT_TRAINS, emu_115) {
         default:                      sw_115_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_115_subtypetext_mucar;
         power: 480/2;
         weight: 28;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/151_161_181_series.pnml" 1
 /*---GF2: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_151_purchase,	                                                    "gfx/JNR/emu151_181/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -22449,6 +22411,7 @@ item(FEAT_TRAINS, emu_151) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -22490,14 +22453,13 @@ item(FEAT_TRAINS, emu_151) {
         default:                      sw_151_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_151_subtypetext_mucar;
         power: 400/2;
         weight: 30;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/165_169_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_165_purchase,	                                                     "gfx/JNR/emu165_169/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -23060,6 +23022,7 @@ item(FEAT_TRAINS, emu_165) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cost_factor:                  19;
         running_cost_factor:          48;
 
@@ -23101,15 +23064,14 @@ item(FEAT_TRAINS, emu_165) {
         default:                      sw_165_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cargo_subtype_text:           sw_165_subtypetext_mucar;
         power: 480/2;
         weight: 29;
       }
 
 }
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JNR/EMU/201_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_201_purchase,	                                                    "gfx/JNR/emu201/purchase.png")               {tmpl_purchase_dh(0, 0)}
 alternative_sprites(spriteset_201_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JNR/emu201/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(0, 0)}
@@ -24433,6 +24395,7 @@ item(FEAT_TRAINS, emu_201) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          47;
 
@@ -24474,14 +24437,13 @@ item(FEAT_TRAINS, emu_201) {
         default:                      sw_201_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_201_subtypetext_mucar;
         power: 600/2;
         weight: 31;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/205_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 //Purchase Sprites
@@ -24801,6 +24763,7 @@ item(FEAT_TRAINS, emu_205) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          46;
 
@@ -24842,14 +24805,13 @@ item(FEAT_TRAINS, emu_205) {
         default:                      sw_205_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_205_subtypetext_mucar;
         power: 480/2;
         weight: 24;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/207900_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_207900_purchase,	                                                    "gfx/JNR/emu207900/purchase.png")               {tmpl_purchase_dh(0, 0)}
 alternative_sprites(spriteset_207900_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JNR/emu207900/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(0, 0)}
@@ -25070,6 +25032,7 @@ item(FEAT_TRAINS, emu_207900) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          51;
 
@@ -25111,14 +25074,13 @@ item(FEAT_TRAINS, emu_207900) {
         default:                      sw_207900_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_207900_subtypetext_mucar;
         power: 600/2;
         weight: 29;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/211_series.pnml" 1
 
 
 /*---GFX: Year Dependent Graphics---*/
@@ -25405,6 +25367,7 @@ item(FEAT_TRAINS, emu_211) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -25446,14 +25409,13 @@ item(FEAT_TRAINS, emu_211) {
         default:                      sw_211_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_211_subtypetext_mucar;
         power: 480/2;
         weight: 23;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/213_series.pnml" 1
 
 
 /*---GFX: Year Dependent Graphics---*/
@@ -25571,6 +25533,7 @@ item(FEAT_TRAINS, emu_213) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -25612,16 +25575,15 @@ item(FEAT_TRAINS, emu_213) {
         default:                      sw_213_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_213_subtypetext_mucar;
         power: 480/2;
         weight: 24;
       }
 
 }
-# 1 "JPplus.pnml" 4
 
 
-# 1 "src/JNR/EMU/401_series.pnml" 1
 /*---GFX: Pantograph Positions---*/
 switch(FEAT_TRAINS, SELF, sw_401_gfx_pantograph_pos_initial_sw1, position_in_vehid_chain){
  0 : spriteset_401_mid_panto_initial;
@@ -25740,6 +25702,7 @@ item(FEAT_TRAINS, emu_401) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          49;
 
@@ -25781,14 +25744,13 @@ item(FEAT_TRAINS, emu_401) {
         default:                      sw_401_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_401_subtypetext_mucar;
         power: 400/2;
         weight: 28;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/403_series.pnml" 1
 /*---GFX: Train Reversing Switches---*/
 /*---END OF SECTION---*/
 /*---GFX: Pantograph Positions---*/
@@ -25909,6 +25871,7 @@ item(FEAT_TRAINS, emu_403) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          49;
 
@@ -25950,14 +25913,13 @@ item(FEAT_TRAINS, emu_403) {
         default:                      sw_403_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_403_subtypetext_mucar;
         power: 480/2;
         weight: 28;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/413_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---SPRITESHEETS BLOCK---*/
@@ -26314,14 +26276,13 @@ item(FEAT_TRAINS, emu_413) {
         default:                      sw_413_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cargo_subtype_text:           sw_413_subtypetext_mucar;
         power: 240;
         weight: 28;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/415_series.pnml" 1
 /*---GFX: Override Spriteset Switches---*/
 switch(FEAT_TRAINS, SELF, sw_415_gfx_spriteset_415_front_kyushu, [build_year>1995 || date_of_last_service>date(1995,1,1)] ){
   1: spriteset_415_front_nv_kyushu;
@@ -26538,6 +26499,7 @@ item(FEAT_TRAINS, emu_415) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          49;
 
@@ -26579,14 +26541,13 @@ item(FEAT_TRAINS, emu_415) {
         default:                      sw_415_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_415_subtypetext_mucar;
         power: 480/2;
         weight: 28;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/415_1500_series.pnml" 1
 /*---GFX: Override Spriteset Switches---*/
 switch(FEAT_TRAINS, SELF, sw_4151500_gfx_spriteset_4151500_mid_kyushu, [build_year>1997 || date_of_last_service>date(1997,1,1)] ){
   1: spriteset_4151500_mid_nv_kyushu;
@@ -26756,6 +26717,7 @@ item(FEAT_TRAINS, emu_4151500) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -26797,14 +26759,13 @@ item(FEAT_TRAINS, emu_4151500) {
         default:                      sw_4151500_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_4151500_subtypetext_mucar;
         power: 480/2;
         weight: 26;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/417_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---SPRITESHEETS BLOCK---*/
@@ -27074,6 +27035,7 @@ item(FEAT_TRAINS, emu_417) {
         reliability_decay:            24;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
         speed:                        100 km/h;
@@ -27111,15 +27073,14 @@ item(FEAT_TRAINS, emu_417) {
         default:                      sw_417_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_417_subtypetext_mucar;
         power: 300;
         weight: 32;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JNR/EMU/485_series.pnml" 1
 /*---GF2: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_485_purchase,	                                                    "gfx/JNR/emu485_489/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -27773,6 +27734,7 @@ item(FEAT_TRAINS, emu_485) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -27814,15 +27776,14 @@ item(FEAT_TRAINS, emu_485) {
         default:                      sw_485_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_485_subtypetext_mucar;
         power: 400/2;
         weight: 30;
       }
 
 }
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JNR/EMU/581_583_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---SPRITESHEETS BLOCK---*/
@@ -28363,15 +28324,14 @@ item(FEAT_TRAINS, emu_583) {
         default:                      sw_583_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_1D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_583_subtypetext_mucar;
         power: 240;
         weight: 35;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JNR/EMU/781_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---SPRITESHEETS BLOCK---*/
@@ -28604,6 +28564,7 @@ item(FEAT_TRAINS, emu_781) {
         reliability_decay:            24;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_1D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  20;
         running_cost_factor:          50;
         speed:                        120 km/h;
@@ -28641,15 +28602,14 @@ item(FEAT_TRAINS, emu_781) {
         default:                      sw_781_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_1D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_781_subtypetext_mucar;
         power: 300;
         weight: 36;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JNR/EMU/711_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_711_purchase,	                                                     "gfx/JRW/emu207/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -29173,6 +29133,7 @@ item(FEAT_TRAINS, emu_711) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -29214,14 +29175,13 @@ item(FEAT_TRAINS, emu_711) {
         default:                      sw_711_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_711_subtypetext_mucar;
         power: 600/2;
         weight: 30;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JNR/EMU/713_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---SPRITESHEETS BLOCK---*/
@@ -29482,6 +29442,7 @@ item(FEAT_TRAINS, emu_713) {
         reliability_decay:            23;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
         speed:                        100 km/h;
@@ -29525,10 +29486,8 @@ item(FEAT_TRAINS, emu_713) {
       }*/
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
 
 //JR-Hokkaido
-# 1 "src/JRH/DMU/KH130_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH130_purchase,	                                                    "gfx/JRH/dmuKH130/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -29656,6 +29615,7 @@ item(FEAT_TRAINS, dmu_kiha130) {
 
         cargo_capacity:               param_capacity_local-15;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -29697,13 +29657,12 @@ item(FEAT_TRAINS, dmu_kiha130) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 32;
       }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRH/DMU/KH141_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH141_purchase,	                                                    "gfx/JRH/dmuKH141/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -29882,6 +29841,7 @@ item(FEAT_TRAINS, dmu_kiha141) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -29923,16 +29883,15 @@ item(FEAT_TRAINS, dmu_kiha141) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 184;
         weight: 32;
       }
 }
-# 1 "JPplus.pnml" 4
 //#include "src/JRH/DMU/KH201_series.pnml"
 
 //JR-East
-# 1 "src/JRE/DMU/KH110_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 /*---END OF SECTION---*/
@@ -30034,6 +29993,7 @@ item(FEAT_TRAINS, dmu_KH110) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          49;
 
@@ -30071,8 +30031,6 @@ item(FEAT_TRAINS, dmu_KH110) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/DMU/KH111_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 /*---END OF SECTION---*/
@@ -30187,6 +30145,7 @@ item(FEAT_TRAINS, dmu_KH111) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          49;
 
@@ -30224,9 +30183,7 @@ item(FEAT_TRAINS, dmu_KH111) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JRE/DMU/KHE120_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 /*---END OF SECTION---*/
@@ -30300,6 +30257,7 @@ item(FEAT_TRAINS, dmu_KHE120) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -30337,8 +30295,6 @@ item(FEAT_TRAINS, dmu_KHE120) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/DMU/KHE130_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 /*---END OF SECTION---*/
@@ -30419,6 +30375,7 @@ item(FEAT_TRAINS, dmu_KHE130) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -30456,8 +30413,6 @@ item(FEAT_TRAINS, dmu_KHE130) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/DMU/KHE131_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 /*---END OF SECTION---*/
@@ -30539,6 +30494,7 @@ item(FEAT_TRAINS, dmu_KHE131) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -30576,9 +30532,7 @@ item(FEAT_TRAINS, dmu_KHE131) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JRE/EMU/215_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---SPRITESHEETS BLOCK---*/
@@ -30845,6 +30799,7 @@ item(FEAT_TRAINS, emu_215) {
         reliability_decay:            24;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
         speed:                        120 km/h;
@@ -30882,14 +30837,13 @@ item(FEAT_TRAINS, emu_215) {
         default:                      sw_215_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_215_subtypetext_mucar;
         power: 240;
         weight: 35;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/E331_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 //Purchase Sprites
@@ -31116,6 +31070,7 @@ item(FEAT_TRAINS, emu_E331) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          67.74; //50
 
@@ -31156,14 +31111,13 @@ item(FEAT_TRAINS, emu_E331) {
         default:                      sw_E331_gfx_mucar_revcheck;
         cargo_capacity:               param_capacity_local-30;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         power: 640/4;
         weight: 16;
         length: sw_E331_length_pos_flipped;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/E235_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 //purchase sprites
@@ -31554,6 +31508,7 @@ item(FEAT_TRAINS, emu_E235) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          46;
 
@@ -31595,14 +31550,13 @@ item(FEAT_TRAINS, emu_E235) {
         default:                      sw_E235_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_E235_subtypetext_mucar;
         power: 560/2;
         weight: 29;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/E233_series.pnml" 1
 /*---GFX: Pantograph Positions---*/
 //E233-0 Chou Line
 switch(FEAT_TRAINS,SELF, sw_E233_gfx_pantograph_numofcars_chou, num_vehs_in_vehid_chain){
@@ -31996,6 +31950,7 @@ item(FEAT_TRAINS, emu_E233) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  13;
         running_cost_factor:          41;
 
@@ -32037,14 +31992,13 @@ item(FEAT_TRAINS, emu_E233) {
         default:                      sw_E233_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_E233_subtypetext_mucar;
         power: 560/2;
         weight: 28;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/E231_series.pnml" 1
 /*---GFX: Pantograph Positions---*/
 //E231-1000 Suburban
 switch(FEAT_TRAINS,SELF, sw_E231_gfx_pantograph_pos_tk_default_dd, position_in_vehid_chain%10){
@@ -32346,6 +32300,7 @@ item(FEAT_TRAINS, emu_E231) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  15;
         running_cost_factor:          43;
 
@@ -32387,14 +32342,13 @@ item(FEAT_TRAINS, emu_E231) {
         default:                      sw_E231_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_E231_subtypetext_mucar;
         power: 380/2;
         weight: 25;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/E217_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 //Purchase Sprites
@@ -32790,6 +32744,7 @@ item(FEAT_TRAINS, emu_E217) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          48;
 
@@ -32831,14 +32786,13 @@ item(FEAT_TRAINS, emu_E217) {
         default:                      sw_E217_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_E217_subtypetext_mucar;
         power: 380/2;
         weight: 25;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/E127_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 //Purchase Sprites
@@ -33053,6 +33007,7 @@ item(FEAT_TRAINS, emu_E127) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -33090,8 +33045,6 @@ item(FEAT_TRAINS, emu_E127) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/209_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_209_purchase,	                                                    "gfx/JRE/emu209/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -34374,6 +34327,7 @@ item(FEAT_TRAINS, emu_209) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          47;
 
@@ -34415,14 +34369,13 @@ item(FEAT_TRAINS, emu_209) {
         default:                      sw_209_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_209_subtypetext_mucar;
         power: 380/2;
         weight: 23;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/107_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 //Purchase Sprites
@@ -34601,6 +34554,7 @@ item(FEAT_TRAINS, emu_107) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -34638,9 +34592,7 @@ item(FEAT_TRAINS, emu_107) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JRE/EMU/E531_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_E531_purchase,	                                                    "gfx/JRE/emuE531/purchase.png")               {tmpl_purchase_dh(0, 0)}
 alternative_sprites(spriteset_E531_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JRE/emuE531/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(0, 0)}
@@ -35149,6 +35101,7 @@ item(FEAT_TRAINS, emu_E531) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -35190,14 +35143,13 @@ item(FEAT_TRAINS, emu_E531) {
         default:                      sw_E531_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_E531_subtypetext_mucar;
         power: 840/2;
         weight: 30;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/E257_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---SPRITESHEETS BLOCK---*/
@@ -36469,14 +36421,13 @@ item(FEAT_TRAINS, emu_E257) {
         default:                      sw_E257_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_E257_subtypetext_mucar;
         power: 290;
         weight: 30;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/E353_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_E353_purchase,	                                                    "gfx/JRE/emuE353/purchase.png")               {tmpl_purchase_dh(0, 0)}
 alternative_sprites(spriteset_E353_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JRE/emuE353/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(0, 0)}
@@ -36786,14 +36737,13 @@ item(FEAT_TRAINS, emu_E353) {
         default:                      sw_E353_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_1D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_E353_subtypetext_mucar;
         power: 400/2;
         weight: 30;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/651_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_651_purchase,	                                                    "gfx/JRE/emu651/purchase.png")               {tmpl_purchase_dh(0, 0)}
 alternative_sprites(spriteset_651_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JRE/emu651/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(0, 0)}
@@ -37156,6 +37106,7 @@ item(FEAT_TRAINS, emu_651) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -37197,15 +37148,14 @@ item(FEAT_TRAINS, emu_651) {
         default:                      sw_651_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_651_subtypetext_mucar;
         power: 400/2;
         weight: 30;
       }
 
 }
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JRE/EMU/719_series.pnml" 1
 /*---!!!THIS HAS BEEN GENERATED BY JpyNML!!!---*/
 /*---END OF SECTION---*/
 /*---GFX: Spritesets---*/
@@ -37428,6 +37378,7 @@ item(FEAT_TRAINS, emu_719) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -37465,8 +37416,6 @@ item(FEAT_TRAINS, emu_719) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRE/EMU/7195000_series.pnml" 1
 /*---!!!THIS HAS BEEN GENERATED BY JpyNML!!!---*/
 /*---END OF SECTION---*/
 /*---GFX: Spritesets---*/
@@ -37605,6 +37554,7 @@ item(FEAT_TRAINS, emu_7195000) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -37642,11 +37592,9 @@ item(FEAT_TRAINS, emu_7195000) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
 
 
 //JR-Central
-# 1 "src/JRC/DMU/KH85_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH85_purchase,	                                                    "gfx/JRC/dmuKH85/purchase.png")               {tmpl_purchase(0, 0)}
@@ -37889,14 +37837,13 @@ item(FEAT_TRAINS, dmu_kiha85) {
         default:                      sw_KH85_gfx_mid;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_KH85_subtypetext_main;
         power: 132;
         weight: 42;
       }
 }
-# 1 "JPplus.pnml" 4
 
-# 1 "src/JRC/EMU/211_56_series.pnml" 1
 
 
 /*---GFX: Year Dependent Graphics---*/
@@ -37953,6 +37900,7 @@ item(FEAT_TRAINS, emu_21156) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -37994,14 +37942,13 @@ item(FEAT_TRAINS, emu_21156) {
         default:                      sw_21156_gfx_mucar_revcheck;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_21156_subtypetext_mucar;
         power: 480/2;
         weight: 23;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRC/EMU/311_series.pnml" 1
 
 
 /*---GFX: Year Dependent Graphics---*/
@@ -38058,6 +38005,7 @@ item(FEAT_TRAINS, emu_311) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -38099,14 +38047,13 @@ item(FEAT_TRAINS, emu_311) {
         default:                      sw_311_gfx_mucar_revcheck;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_311_subtypetext_mucar;
         power: 480/2;
         weight: 23;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRC/EMU/313_series.pnml" 1
 
 /*---GFX: Pantograph Positions---*/
 
@@ -38183,6 +38130,7 @@ item(FEAT_TRAINS, emu_313) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -38224,14 +38172,13 @@ item(FEAT_TRAINS, emu_313) {
         default:                      sw_313_gfx_mucar_revcheck;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_313_subtypetext_mucar;
         power: 740/2;
         weight: 24;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRC/EMU/315_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---SPRITESHEETS BLOCK---*/
@@ -38518,14 +38465,13 @@ item(FEAT_TRAINS, emu_315) {
         default:                      sw_315_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_315_subtypetext_mucar;
         power: 400;
         weight: 31;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/JRC/EMU/373_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_373_purchase,	                                                    "gfx/JRC/emu373/purchase.png")               {tmpl_purchase_dh(1, 0)}
 alternative_sprites(spriteset_373_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JRC/emu373/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(1, 0)}
@@ -38701,6 +38647,7 @@ item(FEAT_TRAINS, emu_373) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -38742,14 +38689,13 @@ item(FEAT_TRAINS, emu_373) {
         default:                      sw_373_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_373_subtypetext_mucar;
         power: 620/2;
         weight: 36;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRC/EMU/383_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_383_purchase,	                                                    "gfx/JRC/emu383/purchase.png")               {tmpl_purchase_dh(1, 0)}
 alternative_sprites(spriteset_383_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JRC/emu383/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(1, 0)}
@@ -39016,6 +38962,7 @@ item(FEAT_TRAINS, emu_383) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -39057,17 +39004,16 @@ item(FEAT_TRAINS, emu_383) {
         default:                      sw_383_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_383_subtypetext_mucar;
         power: 620/2;
         weight: 36;
       }
 
 }
-# 1 "JPplus.pnml" 4
 
 
 //JR-West
-# 1 "src/JRW/EMU/207_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 //Purchase Sprites
@@ -39577,6 +39523,7 @@ item(FEAT_TRAINS, emu_jrw207) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -39618,14 +39565,13 @@ item(FEAT_TRAINS, emu_jrw207) {
         default:                      sw_207_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_207_subtypetext_mucar;
         power: 880/2;
         weight: 25;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/EMU/221_series.pnml" 1
 /*---GFX: Spritesets---*/
 
 /*---END OF SECTION---*/
@@ -39731,6 +39677,7 @@ item(FEAT_TRAINS, emu_221) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -39772,14 +39719,13 @@ item(FEAT_TRAINS, emu_221) {
         default:                      sw_221_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_221_subtypetext_mucar;
         power: 480/2;
         weight: 30;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/EMU/223_0_series.pnml" 1
 /*---GFX: Spritesets---*/
 /*---END OF SECTION---*/
 
@@ -39980,6 +39926,7 @@ item(FEAT_TRAINS, emu_223_0) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -40021,14 +39968,13 @@ item(FEAT_TRAINS, emu_223_0) {
         default:                      sw_223_0_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_223_0_subtypetext_mucar;
         power: 720/2;
         weight: 29;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/EMU/223_1000_series.pnml" 1
 /*---GFX: Spritesets---*/
 /*---END OF SECTION---*/
 
@@ -40177,6 +40123,7 @@ item(FEAT_TRAINS, emu_223_1000) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -40218,14 +40165,13 @@ item(FEAT_TRAINS, emu_223_1000) {
         default:                      sw_223_1000_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_223_1000_subtypetext_mucar;
         power: 880/2;
         weight: 29;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/EMU/225_0_series.pnml" 1
 
 /*---GFX: Override Spriteset Switches---*/
 switch(FEAT_TRAINS, SELF, sw_225_0_gfx_spriteset_225_0_front_0type, [build_year>2015 || date_of_last_service>date(2015,1,1)] ){
@@ -40347,6 +40293,7 @@ item(FEAT_TRAINS, emu_225_0) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -40388,14 +40335,13 @@ item(FEAT_TRAINS, emu_225_0) {
         default:                      sw_225_0_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_225_0_subtypetext_mucar;
         power: 540/2;
         weight: 38;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/EMU/225_5000_series.pnml" 1
 
 /*---GFX: Override Spriteset Switches---*/
 switch(FEAT_TRAINS, SELF, sw_225_5000_gfx_spriteset_225_5000_front_5000type, [build_year>2015 || date_of_last_service>date(2015,1,1)] ){
@@ -40603,6 +40549,7 @@ item(FEAT_TRAINS, emu_225_5000) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -40644,14 +40591,13 @@ item(FEAT_TRAINS, emu_225_5000) {
         default:                      sw_225_5000_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_225_5000_subtypetext_mucar;
         power: 540/2;
         weight: 38;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/EMU/227_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_227_purchase,	                                                    "gfx/JRW/emu227/purchase.png")               {tmpl_purchase_dh(1, 0)}
 alternative_sprites(spriteset_227_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JRW/emu227/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(1, 0)}
@@ -40891,6 +40837,7 @@ item(FEAT_TRAINS, emu_227) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -40932,14 +40879,13 @@ item(FEAT_TRAINS, emu_227) {
         default:                      sw_227_gfx_227_0;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_227_subtypetext_227_0;
         power: 540/2;
         weight: 37;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/EMU/271_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---CONSIST SWITCH BLOCK---*/
@@ -41052,14 +40998,13 @@ item(FEAT_TRAINS, emu_271) {
         default:                      sw_271_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_271_subtypetext_mucar;
         power: 540;
         weight: 32;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/EMU/281_series.pnml" 1
 /*---JpyNML2 Generated---*/
 
 /*---CONSIST SWITCH BLOCK---*/
@@ -41184,14 +41129,13 @@ item(FEAT_TRAINS, emu_281) {
         default:                      sw_281_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_281_subtypetext_mucar;
         power: 540;
         weight: 32;
       }
 }
 /*---END OF SECTION---*/
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/EMU/321_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_321_purchase,	                                                    "gfx/JRW/emu321/purchase.png")               {tmpl_purchase_dh(0, 0)}
 alternative_sprites(spriteset_321_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JRW/emu321/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(0, 0)}
@@ -41392,6 +41336,7 @@ item(FEAT_TRAINS, emu_321) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -41433,14 +41378,13 @@ item(FEAT_TRAINS, emu_321) {
         default:                      sw_321_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_321_subtypetext_321;
         power: 540/2;
         weight: 27;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/EMU/323_series.pnml" 1
 //Purchase Sprites
 spriteset (spriteset_323_purchase,	                                                    "gfx/JRW/emu323/purchase.png")               {tmpl_purchase_dh(1, 0)}
 alternative_sprites(spriteset_323_purchase, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP,         "gfx/JRW/emu323/purchase_32bpp.png")         {tmpl_purchase_dh_32bpp(1, 0)}
@@ -41698,6 +41642,7 @@ item(FEAT_TRAINS, emu_323) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -41739,14 +41684,13 @@ item(FEAT_TRAINS, emu_323) {
         default:                      sw_323_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_323_subtypetext_323;
         power: 440/2;
         weight: 36;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRW/DMU/KH33_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH33_purchase,	                                                    "gfx/JRW/dmuKH33/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -41859,6 +41803,7 @@ item(FEAT_TRAINS, dmu_KH33) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -41899,16 +41844,15 @@ item(FEAT_TRAINS, dmu_KH33) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 40;
       }
 }
-# 1 "JPplus.pnml" 4
 
 
 //JR-Shikoku
-# 1 "src/JRS/EMU/121_series.pnml" 1
 /*---!!!THIS HAS BEEN GENERATED BY JpyNML!!!---*/
 /*---END OF SECTION---*/
 /*---GFX: Spritesets---*/
@@ -42090,6 +42034,7 @@ item(FEAT_TRAINS, emu_121) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -42127,8 +42072,6 @@ item(FEAT_TRAINS, emu_121) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRS/EMU/6000_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_6000_purchase,	                                                     "gfx/JRW/emu207/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -42311,6 +42254,7 @@ item(FEAT_TRAINS, emu_6000) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -42352,14 +42296,13 @@ item(FEAT_TRAINS, emu_6000) {
         default:                      sw_6000_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_6000_subtypetext_mucar;
         power: 640/2;
         weight: 28;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRS/EMU/7200_series.pnml" 1
 /*---!!!THIS HAS BEEN GENERATED BY JpyNML!!!---*/
 /*---END OF SECTION---*/
 /*---GFX: Spritesets---*/
@@ -42475,6 +42418,7 @@ item(FEAT_TRAINS, emu_7200) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  21;
         running_cost_factor:          49;
 
@@ -42512,8 +42456,6 @@ item(FEAT_TRAINS, emu_7200) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRS/EMU/8000_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_8000_purchase,"gfx/JRW/emu207/purchase.png") {tmpl_purchase_dh(0, 0)}
@@ -42778,6 +42720,7 @@ item(FEAT_TRAINS, emu_8000) {
 		reliability_decay : 23;
 		cargo_capacity : param_capacity_express;
 		loading_speed : param_loading_2D;
+        cargo_age_period : param_decay_express;
 		cost_factor : 24;
 		running_cost_factor : 48;
 		speed : 130 km/h;
@@ -42813,15 +42756,15 @@ item(FEAT_TRAINS, emu_8000) {
 	/*Multiple Unit Car*/
 	livery_override(mu_car){
 		default : sw_mu8000_main;
-		cargo_subtype_text : sw_8000_subtypetext_main;		cargo_capacity : param_capacity_express;
+		cargo_subtype_text : sw_8000_subtypetext_main;	
+		cargo_capacity : param_capacity_express;
 		loading_speed : param_loading_2D;
+        cargo_age_period : param_decay_express;
 		power : 800/2;
 		weight : 37;
 	}
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRS/DMU/KH1000_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_KH1000_purchase,	                                                    "gfx/JRS/dmuKH1000/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -42915,6 +42858,7 @@ item(FEAT_TRAINS, dmu_KH1000) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -42952,10 +42896,8 @@ item(FEAT_TRAINS, dmu_KH1000) {
         //start_stop:                   ;
     }
 }
-# 1 "JPplus.pnml" 4
 
 //JR-Kyushu
-# 1 "src/JRK/EMU/303_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_303_purchase,	                                                     "gfx/JRW/emu207/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -43195,6 +43137,7 @@ item(FEAT_TRAINS, emu_303) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -43236,14 +43179,13 @@ item(FEAT_TRAINS, emu_303) {
         default:                      sw_303_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_303_subtypetext_mucar;
         power: 600/2;
         weight: 28;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRK/EMU/811_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_811_purchase,	                                                     "gfx/JRW/emu207/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -43611,6 +43553,7 @@ item(FEAT_TRAINS, emu_811) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -43652,14 +43595,13 @@ item(FEAT_TRAINS, emu_811) {
         default:                      sw_811_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_811_subtypetext_mucar;
         power: 600/2;
         weight: 28;
       }
 
 }
-# 1 "JPplus.pnml" 4
-# 1 "src/JRK/EMU/813_series.pnml" 1
 /*---GFX: Spritesets---*/
 //Purchase Sprites
 spriteset (spriteset_813_purchase,	                                                     "gfx/JRW/emu207/purchase.png")               {tmpl_purchase_dh(0, 0)}
@@ -44018,6 +43960,7 @@ item(FEAT_TRAINS, emu_813) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -44059,17 +44002,16 @@ item(FEAT_TRAINS, emu_813) {
         default:                      sw_813_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_813_subtypetext_mucar;
         power: 600/2;
         weight: 28;
       }
 
 }
-# 1 "JPplus.pnml" 4
 
 
 //GRF OVERRIDE
-# 1 "src/grfoverrides.pnml" 1
 if (param_japansetdisable == 0) {
 	//disable_item(FEAT_TRAINS, 0, 115); //Disables original vehicles
 }
@@ -44290,5 +44232,4 @@ item(FEAT_TRAINS, JRC373, 0x250) {
 
 }
 */
-# 1 "JPplus.pnml" 4
 

--- a/gfx/JRC/dmuHC85/hc85_series.pnml
+++ b/gfx/JRC/dmuHC85/hc85_series.pnml
@@ -70,6 +70,7 @@ item(FEAT_TRAINS, dmu_hc85) {
 		reliability_decay : 23;
 		cargo_capacity : param_capacity_express;
 		loading_speed : param_loading_1D;
+        cargo_age_period : param_decay_express;
 		cost_factor : 30;
 		running_cost_factor : 38;
 		speed : 120 km/h;
@@ -107,6 +108,7 @@ item(FEAT_TRAINS, dmu_hc85) {
 		default : sw_muhc85_main;
 		cargo_capacity : param_capacity_express;
 		loading_speed : param_loading_1D;
+        cargo_age_period : param_decay_express;
 		power : 580/2;
 		weight : 41;
 	}

--- a/src/JGR/EMU/40_series.pnml
+++ b/src/JGR/EMU/40_series.pnml
@@ -423,6 +423,7 @@ item(FEAT_TRAINS, emu_40) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          54;
 
@@ -464,6 +465,7 @@ item(FEAT_TRAINS, emu_40) {
         default:                      sw_EMU40_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_EMU40_subtypetext_mucar;
         power: 132;
         weight: 40;
@@ -481,6 +483,7 @@ item(FEAT_TRAINS, emu_40sinlge) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          54;
 

--- a/src/JGR/EMU/52_series.pnml
+++ b/src/JGR/EMU/52_series.pnml
@@ -986,6 +986,7 @@ item(FEAT_TRAINS, emu_52) {
         default:                      sw_52_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cargo_subtype_text:           sw_52_subtypetext_mucar;
         power: 200;
         weight: 34;

--- a/src/JGR/EMU/6310_series.pnml
+++ b/src/JGR/EMU/6310_series.pnml
@@ -106,6 +106,7 @@ item(FEAT_TRAINS, emu_6310) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          55;
 

--- a/src/JGR/EMU/6340_series.pnml
+++ b/src/JGR/EMU/6340_series.pnml
@@ -165,6 +165,7 @@ item(FEAT_TRAINS, emu_6340) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          55;
 
@@ -206,6 +207,7 @@ item(FEAT_TRAINS, emu_6340) {
         default:                      sw_6340_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_6340_subtypetext_mucar;
         power: 120;
         weight: 23;

--- a/src/JGR/EMU/63_series.pnml
+++ b/src/JGR/EMU/63_series.pnml
@@ -216,6 +216,7 @@ item(FEAT_TRAINS, emu_63) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  16;
         running_cost_factor:          53;
 
@@ -257,6 +258,7 @@ item(FEAT_TRAINS, emu_63) {
         default:                      sw_EMU63_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_EMU63_subtypetext_mucar;
         power: 132;
         weight: 61;

--- a/src/JNR/DMU/KH181_series.pnml
+++ b/src/JNR/DMU/KH181_series.pnml
@@ -219,6 +219,7 @@ item(FEAT_TRAINS, dmu_kiha181) {
         default:                      sw_KH181_gfx_mid;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_KH181_subtypetext_main;
         power: 181;
         weight: 42;

--- a/src/JNR/DMU/KH183_series.pnml
+++ b/src/JNR/DMU/KH183_series.pnml
@@ -296,6 +296,7 @@ item(FEAT_TRAINS, dmu_kiha183) {
         default:                      sw_KH183_gfx_mid;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_KH183_subtypetext_main;
         power: 183;
         weight: 42;

--- a/src/JNR/DMU/KH30_series.pnml
+++ b/src/JNR/DMU/KH30_series.pnml
@@ -110,6 +110,7 @@ item(FEAT_TRAINS, dmu_kiha30) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -151,6 +152,7 @@ item(FEAT_TRAINS, dmu_kiha30) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 32;

--- a/src/JNR/DMU/KH35_series.pnml
+++ b/src/JNR/DMU/KH35_series.pnml
@@ -145,6 +145,7 @@ item(FEAT_TRAINS, dmu_kiha35) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -186,6 +187,7 @@ item(FEAT_TRAINS, dmu_kiha35) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 32;

--- a/src/JNR/DMU/KH40_series.pnml
+++ b/src/JNR/DMU/KH40_series.pnml
@@ -305,6 +305,7 @@ item(FEAT_TRAINS, dmu_kiha40) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -345,6 +346,7 @@ item(FEAT_TRAINS, dmu_kiha40) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 40;

--- a/src/JNR/DMU/KH54_series.pnml
+++ b/src/JNR/DMU/KH54_series.pnml
@@ -133,6 +133,7 @@ item(FEAT_TRAINS, dmu_kiha54) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -173,6 +174,7 @@ item(FEAT_TRAINS, dmu_kiha54) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 54;

--- a/src/JNR/DMU/KH58_series.pnml
+++ b/src/JNR/DMU/KH58_series.pnml
@@ -191,6 +191,7 @@ item(FEAT_TRAINS, dmu_kiha58) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cost_factor:                  15;
         running_cost_factor:          45;
 
@@ -232,6 +233,7 @@ item(FEAT_TRAINS, dmu_kiha58) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 40;

--- a/src/JNR/DMU/KH80_series.pnml
+++ b/src/JNR/DMU/KH80_series.pnml
@@ -495,6 +495,7 @@ item(FEAT_TRAINS, dmu_kiha80) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  18;
         running_cost_factor:          47;
 
@@ -536,6 +537,7 @@ item(FEAT_TRAINS, dmu_kiha80) {
         default:                      sw_KH80_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_KH80_subtypetext_mucar;
         power: 194;
         weight: 40;

--- a/src/JNR/EMU/103_series.pnml
+++ b/src/JNR/EMU/103_series.pnml
@@ -2380,6 +2380,7 @@ item(FEAT_TRAINS, emu_103) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  11;
         running_cost_factor:          41;
 
@@ -2421,6 +2422,7 @@ item(FEAT_TRAINS, emu_103) {
         default:                      sw_103_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_103_subtypetext_mucar;
         power: 440/2;
         weight: 26;

--- a/src/JNR/EMU/111_113_series.pnml
+++ b/src/JNR/EMU/111_113_series.pnml
@@ -1156,6 +1156,7 @@ item(FEAT_TRAINS, emu_113) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  14;
         running_cost_factor:          42;
 
@@ -1197,6 +1198,7 @@ item(FEAT_TRAINS, emu_113) {
         default:                      sw_113_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_113_subtypetext_mucar;
         power: 480/2;
         weight: 29;

--- a/src/JNR/EMU/115_3000_series.pnml
+++ b/src/JNR/EMU/115_3000_series.pnml
@@ -508,6 +508,7 @@ item(FEAT_TRAINS, emu_1153000) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  16;
         running_cost_factor:          45;
 
@@ -549,6 +550,7 @@ item(FEAT_TRAINS, emu_1153000) {
         default:                      sw_1153000_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_1153000_subtypetext_mucar;
         power: 480/2;
         weight: 28;

--- a/src/JNR/EMU/115_series.pnml
+++ b/src/JNR/EMU/115_series.pnml
@@ -3772,6 +3772,7 @@ item(FEAT_TRAINS, emu_115) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  16;
         running_cost_factor:          45;
 
@@ -3813,6 +3814,7 @@ item(FEAT_TRAINS, emu_115) {
         default:                      sw_115_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_115_subtypetext_mucar;
         power: 480/2;
         weight: 28;

--- a/src/JNR/EMU/119_series.pnml
+++ b/src/JNR/EMU/119_series.pnml
@@ -386,6 +386,7 @@ item(FEAT_TRAINS, emu_119) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          54;
 
@@ -427,6 +428,7 @@ item(FEAT_TRAINS, emu_119) {
         default:                      sw_EMU119_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_EMU119_subtypetext_mucar;
         power: 132;
         weight: 119;
@@ -444,6 +446,7 @@ item(FEAT_TRAINS, emu_119sinlge) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          54;
 

--- a/src/JNR/EMU/151_161_181_series.pnml
+++ b/src/JNR/EMU/151_161_181_series.pnml
@@ -710,6 +710,7 @@ item(FEAT_TRAINS, emu_151) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -751,6 +752,7 @@ item(FEAT_TRAINS, emu_151) {
         default:                      sw_151_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_151_subtypetext_mucar;
         power: 400/2;
         weight: 30;

--- a/src/JNR/EMU/165_169_series.pnml
+++ b/src/JNR/EMU/165_169_series.pnml
@@ -560,6 +560,7 @@ item(FEAT_TRAINS, emu_165) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cost_factor:                  19;
         running_cost_factor:          48;
 
@@ -601,6 +602,7 @@ item(FEAT_TRAINS, emu_165) {
         default:                      sw_165_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cargo_subtype_text:           sw_165_subtypetext_mucar;
         power: 480/2;
         weight: 29;

--- a/src/JNR/EMU/201_series.pnml
+++ b/src/JNR/EMU/201_series.pnml
@@ -1321,6 +1321,7 @@ item(FEAT_TRAINS, emu_201) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          47;
 
@@ -1362,6 +1363,7 @@ item(FEAT_TRAINS, emu_201) {
         default:                      sw_201_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_201_subtypetext_mucar;
         power: 600/2;
         weight: 31;

--- a/src/JNR/EMU/205_series.pnml
+++ b/src/JNR/EMU/205_series.pnml
@@ -317,6 +317,7 @@ item(FEAT_TRAINS, emu_205) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          46;
 
@@ -358,6 +359,7 @@ item(FEAT_TRAINS, emu_205) {
         default:                      sw_205_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_205_subtypetext_mucar;
         power: 480/2;
         weight: 24;

--- a/src/JNR/EMU/207900_series.pnml
+++ b/src/JNR/EMU/207900_series.pnml
@@ -218,6 +218,7 @@ item(FEAT_TRAINS, emu_207900) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          51;
 
@@ -259,6 +260,7 @@ item(FEAT_TRAINS, emu_207900) {
         default:                      sw_207900_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_207900_subtypetext_mucar;
         power: 600/2;
         weight: 29;

--- a/src/JNR/EMU/211_series.pnml
+++ b/src/JNR/EMU/211_series.pnml
@@ -284,6 +284,7 @@ item(FEAT_TRAINS, emu_211) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -325,6 +326,7 @@ item(FEAT_TRAINS, emu_211) {
         default:                      sw_211_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_211_subtypetext_mucar;
         power: 480/2;
         weight: 23;

--- a/src/JNR/EMU/213_series.pnml
+++ b/src/JNR/EMU/213_series.pnml
@@ -115,6 +115,7 @@ item(FEAT_TRAINS, emu_213) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -156,6 +157,7 @@ item(FEAT_TRAINS, emu_213) {
         default:                      sw_213_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_213_subtypetext_mucar;
         power: 480/2;
         weight: 24;

--- a/src/JNR/EMU/401_series.pnml
+++ b/src/JNR/EMU/401_series.pnml
@@ -116,6 +116,7 @@ item(FEAT_TRAINS, emu_401) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          49;
 
@@ -157,6 +158,7 @@ item(FEAT_TRAINS, emu_401) {
         default:                      sw_401_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_401_subtypetext_mucar;
         power: 400/2;
         weight: 28;

--- a/src/JNR/EMU/403_series.pnml
+++ b/src/JNR/EMU/403_series.pnml
@@ -118,6 +118,7 @@ item(FEAT_TRAINS, emu_403) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          49;
 
@@ -159,6 +160,7 @@ item(FEAT_TRAINS, emu_403) {
         default:                      sw_403_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_403_subtypetext_mucar;
         power: 480/2;
         weight: 28;

--- a/src/JNR/EMU/413_series.pnml
+++ b/src/JNR/EMU/413_series.pnml
@@ -354,6 +354,7 @@ item(FEAT_TRAINS, emu_413) {
         default:                      sw_413_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cargo_subtype_text:           sw_413_subtypetext_mucar;
         power: 240;
         weight: 28;

--- a/src/JNR/EMU/415_1500_series.pnml
+++ b/src/JNR/EMU/415_1500_series.pnml
@@ -167,6 +167,7 @@ item(FEAT_TRAINS, emu_4151500) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -208,6 +209,7 @@ item(FEAT_TRAINS, emu_4151500) {
         default:                      sw_4151500_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_4151500_subtypetext_mucar;
         power: 480/2;
         weight: 26;

--- a/src/JNR/EMU/415_series.pnml
+++ b/src/JNR/EMU/415_series.pnml
@@ -214,6 +214,7 @@ item(FEAT_TRAINS, emu_415) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          49;
 
@@ -255,6 +256,7 @@ item(FEAT_TRAINS, emu_415) {
         default:                      sw_415_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_415_subtypetext_mucar;
         power: 480/2;
         weight: 28;

--- a/src/JNR/EMU/417_series.pnml
+++ b/src/JNR/EMU/417_series.pnml
@@ -267,6 +267,7 @@ item(FEAT_TRAINS, emu_417) {
         reliability_decay:            24;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
         speed:                        100 km/h;
@@ -304,6 +305,7 @@ item(FEAT_TRAINS, emu_417) {
         default:                      sw_417_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_417_subtypetext_mucar;
         power: 300;
         weight: 32;

--- a/src/JNR/EMU/485_series.pnml
+++ b/src/JNR/EMU/485_series.pnml
@@ -651,6 +651,7 @@ item(FEAT_TRAINS, emu_485) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -692,6 +693,7 @@ item(FEAT_TRAINS, emu_485) {
         default:                      sw_485_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_485_subtypetext_mucar;
         power: 400/2;
         weight: 30;

--- a/src/JNR/EMU/581_583_series.pnml
+++ b/src/JNR/EMU/581_583_series.pnml
@@ -538,6 +538,7 @@ item(FEAT_TRAINS, emu_583) {
         default:                      sw_583_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_1D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_583_subtypetext_mucar;
         power: 240;
         weight: 35;

--- a/src/JNR/EMU/70_series.pnml
+++ b/src/JNR/EMU/70_series.pnml
@@ -1118,6 +1118,7 @@ item(FEAT_TRAINS, emu_70) {
         reliability_decay:            23;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
         speed:                        100 km/h;
@@ -1155,6 +1156,7 @@ item(FEAT_TRAINS, emu_70) {
         default:                      sw_70_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_70_subtypetext_mucar;
         power: 284;
         weight: 32;

--- a/src/JNR/EMU/711_series.pnml
+++ b/src/JNR/EMU/711_series.pnml
@@ -521,6 +521,7 @@ item(FEAT_TRAINS, emu_711) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -562,6 +563,7 @@ item(FEAT_TRAINS, emu_711) {
         default:                      sw_711_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_711_subtypetext_mucar;
         power: 600/2;
         weight: 30;

--- a/src/JNR/EMU/713_series.pnml
+++ b/src/JNR/EMU/713_series.pnml
@@ -258,6 +258,7 @@ item(FEAT_TRAINS, emu_713) {
         reliability_decay:            23;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
         speed:                        100 km/h;

--- a/src/JNR/EMU/781_series.pnml
+++ b/src/JNR/EMU/781_series.pnml
@@ -230,6 +230,7 @@ item(FEAT_TRAINS, emu_781) {
         reliability_decay:            24;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_1D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  20;
         running_cost_factor:          50;
         speed:                        120 km/h;
@@ -267,6 +268,7 @@ item(FEAT_TRAINS, emu_781) {
         default:                      sw_781_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_1D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_781_subtypetext_mucar;
         power: 300;
         weight: 36;

--- a/src/JNR/EMU/80_series.pnml
+++ b/src/JNR/EMU/80_series.pnml
@@ -613,6 +613,7 @@ item(FEAT_TRAINS, emu_80) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -654,6 +655,7 @@ item(FEAT_TRAINS, emu_80) {
         default:                      sw_80_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_rapid;
         cargo_subtype_text:           sw_80_subtypetext_mucar;
         power: 568/2;
         weight: 32;

--- a/src/JRC/DMU/KH85_series.pnml
+++ b/src/JRC/DMU/KH85_series.pnml
@@ -240,6 +240,7 @@ item(FEAT_TRAINS, dmu_kiha85) {
         default:                      sw_KH85_gfx_mid;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_KH85_subtypetext_main;
         power: 132;
         weight: 42;

--- a/src/JRC/EMU/211_56_series.pnml
+++ b/src/JRC/EMU/211_56_series.pnml
@@ -54,6 +54,7 @@ item(FEAT_TRAINS, emu_21156) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -95,6 +96,7 @@ item(FEAT_TRAINS, emu_21156) {
         default:                      sw_21156_gfx_mucar_revcheck;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_21156_subtypetext_mucar;
         power: 480/2;
         weight: 23;

--- a/src/JRC/EMU/311_series.pnml
+++ b/src/JRC/EMU/311_series.pnml
@@ -54,6 +54,7 @@ item(FEAT_TRAINS, emu_311) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -95,6 +96,7 @@ item(FEAT_TRAINS, emu_311) {
         default:                      sw_311_gfx_mucar_revcheck;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_311_subtypetext_mucar;
         power: 480/2;
         weight: 23;

--- a/src/JRC/EMU/313_series.pnml
+++ b/src/JRC/EMU/313_series.pnml
@@ -74,6 +74,7 @@ item(FEAT_TRAINS, emu_313) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -115,6 +116,7 @@ item(FEAT_TRAINS, emu_313) {
         default:                      sw_313_gfx_mucar_revcheck;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_313_subtypetext_mucar;
         power: 740/2;
         weight: 24;

--- a/src/JRC/EMU/315_series.pnml
+++ b/src/JRC/EMU/315_series.pnml
@@ -284,6 +284,7 @@ item(FEAT_TRAINS, emu_315) {
         default:                      sw_315_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_315_subtypetext_mucar;
         power: 400;
         weight: 31;

--- a/src/JRC/EMU/373_series.pnml
+++ b/src/JRC/EMU/373_series.pnml
@@ -173,6 +173,7 @@ item(FEAT_TRAINS, emu_373) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -214,6 +215,7 @@ item(FEAT_TRAINS, emu_373) {
         default:                      sw_373_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_373_subtypetext_mucar;
         power: 620/2;
         weight: 36;

--- a/src/JRC/EMU/383_series.pnml
+++ b/src/JRC/EMU/383_series.pnml
@@ -264,6 +264,7 @@ item(FEAT_TRAINS, emu_383) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -305,6 +306,7 @@ item(FEAT_TRAINS, emu_383) {
         default:                      sw_383_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_383_subtypetext_mucar;
         power: 620/2;
         weight: 36;

--- a/src/JRE/DMU/KH110_series.pnml
+++ b/src/JRE/DMU/KH110_series.pnml
@@ -99,6 +99,7 @@ item(FEAT_TRAINS, dmu_KH110) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          49;
 

--- a/src/JRE/DMU/KH111_series.pnml
+++ b/src/JRE/DMU/KH111_series.pnml
@@ -112,6 +112,7 @@ item(FEAT_TRAINS, dmu_KH111) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          49;
 

--- a/src/JRE/DMU/KHE120_series.pnml
+++ b/src/JRE/DMU/KHE120_series.pnml
@@ -71,6 +71,7 @@ item(FEAT_TRAINS, dmu_KHE120) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 

--- a/src/JRE/DMU/KHE130_series.pnml
+++ b/src/JRE/DMU/KHE130_series.pnml
@@ -78,6 +78,7 @@ item(FEAT_TRAINS, dmu_KHE130) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 

--- a/src/JRE/DMU/KHE131_series.pnml
+++ b/src/JRE/DMU/KHE131_series.pnml
@@ -79,6 +79,7 @@ item(FEAT_TRAINS, dmu_KHE131) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 

--- a/src/JRE/EMU/107_series.pnml
+++ b/src/JRE/EMU/107_series.pnml
@@ -176,6 +176,7 @@ item(FEAT_TRAINS, emu_107) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 

--- a/src/JRE/EMU/209_series.pnml
+++ b/src/JRE/EMU/209_series.pnml
@@ -1280,6 +1280,7 @@ item(FEAT_TRAINS, emu_209) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          47;
 
@@ -1321,6 +1322,7 @@ item(FEAT_TRAINS, emu_209) {
         default:                      sw_209_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_209_subtypetext_mucar;
         power: 380/2;
         weight: 23;

--- a/src/JRE/EMU/215_series.pnml
+++ b/src/JRE/EMU/215_series.pnml
@@ -264,6 +264,7 @@ item(FEAT_TRAINS, emu_215) {
         reliability_decay:            24;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
         speed:                        120 km/h;
@@ -301,6 +302,7 @@ item(FEAT_TRAINS, emu_215) {
         default:                      sw_215_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_215_subtypetext_mucar;
         power: 240;
         weight: 35;

--- a/src/JRE/EMU/651_series.pnml
+++ b/src/JRE/EMU/651_series.pnml
@@ -360,6 +360,7 @@ item(FEAT_TRAINS, emu_651) {
 
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -401,6 +402,7 @@ item(FEAT_TRAINS, emu_651) {
         default:                      sw_651_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_651_subtypetext_mucar;
         power: 400/2;
         weight: 30;

--- a/src/JRE/EMU/7195000_series.pnml
+++ b/src/JRE/EMU/7195000_series.pnml
@@ -136,6 +136,7 @@ item(FEAT_TRAINS, emu_7195000) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 

--- a/src/JRE/EMU/719_series.pnml
+++ b/src/JRE/EMU/719_series.pnml
@@ -220,6 +220,7 @@ item(FEAT_TRAINS, emu_719) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 

--- a/src/JRE/EMU/E127_series.pnml
+++ b/src/JRE/EMU/E127_series.pnml
@@ -212,6 +212,7 @@ item(FEAT_TRAINS, emu_E127) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 

--- a/src/JRE/EMU/E217_series.pnml
+++ b/src/JRE/EMU/E217_series.pnml
@@ -393,6 +393,7 @@ item(FEAT_TRAINS, emu_E217) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          48;
 
@@ -434,6 +435,7 @@ item(FEAT_TRAINS, emu_E217) {
         default:                      sw_E217_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_E217_subtypetext_mucar;
         power: 380/2;
         weight: 25;

--- a/src/JRE/EMU/E231_series.pnml
+++ b/src/JRE/EMU/E231_series.pnml
@@ -299,6 +299,7 @@ item(FEAT_TRAINS, emu_E231) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  15;
         running_cost_factor:          43;
 
@@ -340,6 +341,7 @@ item(FEAT_TRAINS, emu_E231) {
         default:                      sw_E231_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_E231_subtypetext_mucar;
         power: 380/2;
         weight: 25;

--- a/src/JRE/EMU/E233_series.pnml
+++ b/src/JRE/EMU/E233_series.pnml
@@ -391,6 +391,7 @@ item(FEAT_TRAINS, emu_E233) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  13;
         running_cost_factor:          41;
 
@@ -432,6 +433,7 @@ item(FEAT_TRAINS, emu_E233) {
         default:                      sw_E233_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_E233_subtypetext_mucar;
         power: 560/2;
         weight: 28;

--- a/src/JRE/EMU/E235_series.pnml
+++ b/src/JRE/EMU/E235_series.pnml
@@ -388,6 +388,7 @@ item(FEAT_TRAINS, emu_E235) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  17;
         running_cost_factor:          46;
 
@@ -429,6 +430,7 @@ item(FEAT_TRAINS, emu_E235) {
         default:                      sw_E235_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_E235_subtypetext_mucar;
         power: 560/2;
         weight: 29;

--- a/src/JRE/EMU/E257_series.pnml
+++ b/src/JRE/EMU/E257_series.pnml
@@ -1269,6 +1269,7 @@ item(FEAT_TRAINS, emu_E257) {
         default:                      sw_E257_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_E257_subtypetext_mucar;
         power: 290;
         weight: 30;

--- a/src/JRE/EMU/E331_series.pnml
+++ b/src/JRE/EMU/E331_series.pnml
@@ -224,6 +224,7 @@ item(FEAT_TRAINS, emu_E331) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          67.74; //50
 
@@ -264,6 +265,7 @@ item(FEAT_TRAINS, emu_E331) {
         default:                      sw_E331_gfx_mucar_revcheck;
         cargo_capacity:               param_capacity_local-30;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         power: 640/4;
         weight: 16;
         length: sw_E331_length_pos_flipped;

--- a/src/JRE/EMU/E353_series.pnml
+++ b/src/JRE/EMU/E353_series.pnml
@@ -307,6 +307,7 @@ item(FEAT_TRAINS, emu_E353) {
         default:                      sw_E353_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_1D;
+        cargo_age_period:             param_decay_express;
         //cargo_subtype_text:           sw_E353_subtypetext_mucar;
         power: 400/2;
         weight: 30;

--- a/src/JRE/EMU/E531_series.pnml
+++ b/src/JRE/EMU/E531_series.pnml
@@ -506,6 +506,7 @@ item(FEAT_TRAINS, emu_E531) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -547,6 +548,7 @@ item(FEAT_TRAINS, emu_E531) {
         default:                      sw_E531_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_E531_subtypetext_mucar;
         power: 840/2;
         weight: 30;

--- a/src/JRH/DMU/KH130_series.pnml
+++ b/src/JRH/DMU/KH130_series.pnml
@@ -125,6 +125,7 @@ item(FEAT_TRAINS, dmu_kiha130) {
 
         cargo_capacity:               param_capacity_local-15;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -166,6 +167,7 @@ item(FEAT_TRAINS, dmu_kiha130) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 32;

--- a/src/JRH/DMU/KH141_series.pnml
+++ b/src/JRH/DMU/KH141_series.pnml
@@ -176,6 +176,7 @@ item(FEAT_TRAINS, dmu_kiha141) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -217,6 +218,7 @@ item(FEAT_TRAINS, dmu_kiha141) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 184;
         weight: 32;

--- a/src/JRH/DMU/KH201_series.pnml
+++ b/src/JRH/DMU/KH201_series.pnml
@@ -171,8 +171,9 @@ item(FEAT_TRAINS, dmu_kiha201) {
         vehicle_life:                 46;
         reliability_decay:            21;
 
-        cargo_capacity:               param_capacity_rapid;
+        cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -212,8 +213,9 @@ item(FEAT_TRAINS, dmu_kiha201) {
     /*Multiple Unit Car*/
       livery_override(mu_car){
         default:                      sw_KH201_gfx_mucar;
-        cargo_capacity:               param_capacity_express;
+        cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_KH201_subtypetext_mucar;
         power: 620/2;
         weight: 36;

--- a/src/JRK/EMU/303_series.pnml
+++ b/src/JRK/EMU/303_series.pnml
@@ -237,6 +237,7 @@ item(FEAT_TRAINS, emu_303) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -278,6 +279,7 @@ item(FEAT_TRAINS, emu_303) {
         default:                      sw_303_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_303_subtypetext_mucar;
         power: 600/2;
         weight: 28;

--- a/src/JRK/EMU/811_series.pnml
+++ b/src/JRK/EMU/811_series.pnml
@@ -365,6 +365,7 @@ item(FEAT_TRAINS, emu_811) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -406,6 +407,7 @@ item(FEAT_TRAINS, emu_811) {
         default:                      sw_811_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_811_subtypetext_mucar;
         power: 600/2;
         weight: 28;

--- a/src/JRK/EMU/813_series.pnml
+++ b/src/JRK/EMU/813_series.pnml
@@ -356,6 +356,7 @@ item(FEAT_TRAINS, emu_813) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -397,6 +398,7 @@ item(FEAT_TRAINS, emu_813) {
         default:                      sw_813_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_813_subtypetext_mucar;
         power: 600/2;
         weight: 28;

--- a/src/JRS/DMU/KH1000_series.pnml
+++ b/src/JRS/DMU/KH1000_series.pnml
@@ -91,6 +91,7 @@ item(FEAT_TRAINS, dmu_KH1000) {
 
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 

--- a/src/JRS/EMU/121_series.pnml
+++ b/src/JRS/EMU/121_series.pnml
@@ -179,6 +179,7 @@ item(FEAT_TRAINS, emu_121) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 

--- a/src/JRS/EMU/6000_series.pnml
+++ b/src/JRS/EMU/6000_series.pnml
@@ -180,6 +180,7 @@ item(FEAT_TRAINS, emu_6000) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  20;
         running_cost_factor:          50;
 
@@ -221,6 +222,7 @@ item(FEAT_TRAINS, emu_6000) {
         default:                      sw_6000_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_6000_subtypetext_mucar;
         power: 640/2;
         weight: 28;

--- a/src/JRS/EMU/7200_series.pnml
+++ b/src/JRS/EMU/7200_series.pnml
@@ -113,6 +113,7 @@ item(FEAT_TRAINS, emu_7200) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  21;
         running_cost_factor:          49;
 

--- a/src/JRS/EMU/8000_series.pnml
+++ b/src/JRS/EMU/8000_series.pnml
@@ -262,6 +262,7 @@ item(FEAT_TRAINS, emu_8000) {
 		reliability_decay : 23;
 		cargo_capacity : param_capacity_express;
 		loading_speed : param_loading_2D;
+        cargo_age_period : param_decay_express;
 		cost_factor : 24;
 		running_cost_factor : 48;
 		speed : 130 km/h;
@@ -297,8 +298,10 @@ item(FEAT_TRAINS, emu_8000) {
 	/*Multiple Unit Car*/
 	livery_override(mu_car){
 		default : sw_mu8000_main;
-		cargo_subtype_text : sw_8000_subtypetext_main;		cargo_capacity : param_capacity_express;
+		cargo_subtype_text : sw_8000_subtypetext_main;	
+		cargo_capacity : param_capacity_express;
 		loading_speed : param_loading_2D;
+        cargo_age_period : param_decay_express;
 		power : 800/2;
 		weight : 37;
 	}

--- a/src/JRW/DMU/KH33_series.pnml
+++ b/src/JRW/DMU/KH33_series.pnml
@@ -110,6 +110,7 @@ item(FEAT_TRAINS, dmu_KH33) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -150,6 +151,7 @@ item(FEAT_TRAINS, dmu_KH33) {
         default:                      sw_JNR_KH_gfx_mucar;
         cargo_capacity:               param_capacity_rapid;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_JNR_KH_subtypetext_mucar;
         power: 132;
         weight: 40;

--- a/src/JRW/EMU/207_series.pnml
+++ b/src/JRW/EMU/207_series.pnml
@@ -507,6 +507,7 @@ item(FEAT_TRAINS, emu_jrw207) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -548,6 +549,7 @@ item(FEAT_TRAINS, emu_jrw207) {
         default:                      sw_207_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_207_subtypetext_mucar;
         power: 880/2;
         weight: 25;

--- a/src/JRW/EMU/221_series.pnml
+++ b/src/JRW/EMU/221_series.pnml
@@ -103,6 +103,7 @@ item(FEAT_TRAINS, emu_221) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  19;
         running_cost_factor:          49;
 
@@ -144,6 +145,7 @@ item(FEAT_TRAINS, emu_221) {
         default:                      sw_221_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_221_subtypetext_mucar;
         power: 480/2;
         weight: 30;

--- a/src/JRW/EMU/223_0_series.pnml
+++ b/src/JRW/EMU/223_0_series.pnml
@@ -198,6 +198,7 @@ item(FEAT_TRAINS, emu_223_0) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -239,6 +240,7 @@ item(FEAT_TRAINS, emu_223_0) {
         default:                      sw_223_0_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_223_0_subtypetext_mucar;
         power: 720/2;
         weight: 29;

--- a/src/JRW/EMU/223_1000_series.pnml
+++ b/src/JRW/EMU/223_1000_series.pnml
@@ -146,6 +146,7 @@ item(FEAT_TRAINS, emu_223_1000) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -187,6 +188,7 @@ item(FEAT_TRAINS, emu_223_1000) {
         default:                      sw_223_1000_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_223_1000_subtypetext_mucar;
         power: 880/2;
         weight: 29;

--- a/src/JRW/EMU/225_0_series.pnml
+++ b/src/JRW/EMU/225_0_series.pnml
@@ -119,6 +119,7 @@ item(FEAT_TRAINS, emu_225_0) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -160,6 +161,7 @@ item(FEAT_TRAINS, emu_225_0) {
         default:                      sw_225_0_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_225_0_subtypetext_mucar;
         power: 540/2;
         weight: 38;

--- a/src/JRW/EMU/225_5000_series.pnml
+++ b/src/JRW/EMU/225_5000_series.pnml
@@ -205,6 +205,7 @@ item(FEAT_TRAINS, emu_225_5000) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -246,6 +247,7 @@ item(FEAT_TRAINS, emu_225_5000) {
         default:                      sw_225_5000_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_225_5000_subtypetext_mucar;
         power: 540/2;
         weight: 38;

--- a/src/JRW/EMU/227_series.pnml
+++ b/src/JRW/EMU/227_series.pnml
@@ -237,6 +237,7 @@ item(FEAT_TRAINS, emu_227) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -278,6 +279,7 @@ item(FEAT_TRAINS, emu_227) {
         default:                      sw_227_gfx_227_0;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cargo_subtype_text:           sw_227_subtypetext_227_0;
         power: 540/2;
         weight: 37;

--- a/src/JRW/EMU/271_series.pnml
+++ b/src/JRW/EMU/271_series.pnml
@@ -110,6 +110,7 @@ item(FEAT_TRAINS, emu_271) {
         default:                      sw_271_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_271_subtypetext_mucar;
         power: 540;
         weight: 32;

--- a/src/JRW/EMU/281_series.pnml
+++ b/src/JRW/EMU/281_series.pnml
@@ -122,6 +122,7 @@ item(FEAT_TRAINS, emu_281) {
         default:                      sw_281_gfx_mucar;
         cargo_capacity:               param_capacity_express;
         loading_speed:                param_loading_2D;
+        cargo_age_period:             param_decay_express;
         cargo_subtype_text:           sw_281_subtypetext_mucar;
         power: 540;
         weight: 32;

--- a/src/JRW/EMU/321_series.pnml
+++ b/src/JRW/EMU/321_series.pnml
@@ -198,6 +198,7 @@ item(FEAT_TRAINS, emu_321) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -239,6 +240,7 @@ item(FEAT_TRAINS, emu_321) {
         default:                      sw_321_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_4D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_321_subtypetext_321;
         power: 540/2;
         weight: 27;

--- a/src/JRW/EMU/323_series.pnml
+++ b/src/JRW/EMU/323_series.pnml
@@ -255,6 +255,7 @@ item(FEAT_TRAINS, emu_323) {
 
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         cost_factor:                  18;
         running_cost_factor:          48;
 
@@ -296,6 +297,7 @@ item(FEAT_TRAINS, emu_323) {
         default:                      sw_323_gfx_mucar;
         cargo_capacity:               param_capacity_local;
         loading_speed:                param_loading_3D;
+        cargo_age_period:             param_decay_local;
         //cargo_subtype_text:           sw_323_subtypetext_323;
         power: 440/2;
         weight: 36;

--- a/src/OTHER/mucar.pnml
+++ b/src/OTHER/mucar.pnml
@@ -17,6 +17,7 @@ item(FEAT_TRAINS, mu_car) {
                 speed: 0 km/h;
                 power: 0 hp;
                 cargo_capacity: 1;
+                cargo_age_period: 185;
                 weight: 0 ton;
                 tractive_effort_coefficient: 0.3;
                 air_drag_coefficient: 0;


### PR DESCRIPTION
Tweak the cargo_age_period of all MUs: they are finally assigned to the values defined by the parameter.
- Notice: cargo_age_period should also be set in livery override of MU cars, or MU cars would remain the default cargo aging value.
- Some MUs with "rapid" capacity are set with "local" cargo aging values, this is because they are not really Rapid/Express type MUs. Mostly they are "short" DMUs with smaller capacity than normal ones.